### PR TITLE
Temporarily fix the dmg/-quiet issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ branches:
 
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-  - chef exec bundle update
+  - chef exec bundle install --without=development integration
 
 before_script:
   # Pending ENV support in Kitchen's Rake tasks and not just the CLI
   - cp .kitchen.travis.yml .kitchen.local.yml
 
 script:
-  - chef exec bundle exec kitchen test -c 2
+  - chef exec kitchen test
 
 after_script:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Steam Cookbook CHANGELOG
 v?.?.? (????-??-??)
 -------------------
 - Use Chef 12-style provider resolution
+- Fix issue with Steam .dmg package failing on OS X
 
 v0.1.0 (2015-06-02)
 -------------------

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :test do
   gem 'coveralls'
   gem 'fauxhai'
   gem 'test-kitchen'
-  gem 'kitchen-digitalocean', '>= 0.8.0'
   gem 'kitchen-docker'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
@@ -32,7 +31,6 @@ end
 
 group :integration do
   gem 'serverspec', '>= 2'
-  gem 'cucumber'
 end
 
 group :deploy do

--- a/Rakefile
+++ b/Rakefile
@@ -4,21 +4,12 @@ require 'rubygems'
 require 'English'
 require 'bundler/setup'
 require 'rubocop/rake_task'
-require 'cane/rake_task'
 require 'rspec/core/rake_task'
 require 'foodcritic'
 require 'kitchen/rake_tasks'
 require 'stove/rake_task'
 
-Cane::RakeTask.new
-
 RuboCop::RakeTask.new
-
-desc 'Display LOC stats'
-task :loc do
-  puts "\n## LOC Stats"
-  Kernel.system 'countloc -r .'
-end
 
 FoodCritic::Rake::LintTask.new do |f|
   f.options = { fail_tags: %w(any) }
@@ -30,4 +21,4 @@ Kitchen::RakeTasks.new
 
 Stove::RakeTask.new
 
-task default: %w(cane rubocop loc foodcritic spec)
+task default: %w(rubocop foodcritic spec)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ install:
   - SET PATH=C:\opscode\chefdk\bin;%PATH%
 
 build_script:
-  - chef exec bundle update
+  - chef exec bundle install --without=development integration
   - copy .kitchen.appveyor.yml .kitchen.local.yml
 
 test_script:
-  - chef exec bundle exec kitchen test -c 2
+  - chef exec kitchen test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.1.6
+    version: 2.2.3
   services:
     - docker
 
@@ -8,8 +8,10 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
-    - bundle update
-    - rvm-exec 2.0.0-p645 bundle update
+    - gem which berkshelf || gem install -V berkshelf
+    - rvm-exec 2.0.0-p645 gem which berkshelf || rvm-exec 2.0.0-p645 gem install -V berkshelf
+    - bundle install --without=development integration
+    - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:
     - /home/ubuntu/.rvm/gems
 

--- a/spec/libraries/provider_steam_app_debian_spec.rb
+++ b/spec/libraries/provider_steam_app_debian_spec.rb
@@ -81,8 +81,9 @@ describe Chef::Provider::SteamApp::Debian do
 
   describe '#download_path' do
     it 'returns a path under the Chef cache dir' do
-      expected = "#{Chef::Config[:file_cache_path]}/steam.deb"
-      expect(provider.send(:download_path)).to eq(expected)
+      expect(provider.send(:download_path)).to eq(
+        "#{Chef::Config[:file_cache_path]}/steam.deb"
+      )
     end
   end
 

--- a/spec/libraries/provider_steam_app_debian_spec.rb
+++ b/spec/libraries/provider_steam_app_debian_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_steam_app_debian'
 
 describe Chef::Provider::SteamApp::Debian do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SteamApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SteamApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_steam_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_steam_app_mac_os_x_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_steam_app_mac_os_x'
 
 describe Chef::Provider::SteamApp::MacOsX do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SteamApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SteamApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }
@@ -23,12 +24,40 @@ describe Chef::Provider::SteamApp::MacOsX do
   end
 
   describe '#install!' do
-    it 'uses a dmg_package resource to install Steam' do
+    before(:each) do
+      %i(remote_file attach_dmg execute detach_dmg).each do |m|
+        allow_any_instance_of(described_class).to receive(m)
+      end
+    end
+
+    it 'downloads the .dmg file' do
       p = provider
-      expect(p).to receive(:dmg_package).with('Steam').and_yield
+      expect(p).to receive(:remote_file)
+        .with("#{Chef::Config[:file_cache_path]}/steam.dmg").and_yield
       expect(p).to receive(:source).with(described_class::URL)
-      expect(p).to receive(:accept_eula).with(true)
-      expect(p).to receive(:action).with(:install)
+      expect(p).to receive(:not_if).and_yield
+      expect(File).to receive(:exist?).with(described_class::PATH)
+      p.send(:install!)
+    end
+
+    it 'attaches the .dmg file' do
+      p = provider
+      expect(p).to receive(:attach_dmg)
+      p.send(:install!)
+    end
+
+    it 'rsyncs the .dmg contents' do
+      p = provider
+      expect(p).to receive(:execute)
+        .with('rsync -a /Volumes/Steam/Steam.app /Applications/').and_yield
+      expect(p).to receive(:not_if).and_yield
+      expect(File).to receive(:exist?).with(described_class::PATH)
+      p.send(:install!)
+    end
+
+    it 'detaches the .dmg file' do
+      p = provider
+      expect(p).to receive(:detach_dmg)
       p.send(:install!)
     end
   end
@@ -45,6 +74,44 @@ describe Chef::Provider::SteamApp::MacOsX do
         expect(p).to receive(:action).with(:delete)
       end
       p.send(:remove!)
+    end
+  end
+
+  describe '#attach_dmg' do
+    it 'attaches the .dmg file' do
+      p = provider
+      expect(p).to receive(:execute).with(
+        "echo Y | PAGER=true hdiutil attach '" \
+        "#{Chef::Config[:file_cache_path]}/steam.dmg'"
+      ).and_yield
+      expect(p).to receive(:not_if).with(
+        "hdiutil info | grep -q 'image-path.*" \
+        "#{Chef::Config[:file_cache_path]}/steam.dmg'"
+      )
+      expect(p).to receive(:not_if).and_yield
+      expect(File).to receive(:exist?).with(described_class::PATH)
+      p.send(:attach_dmg)
+    end
+  end
+
+  describe '#detach_dmg' do
+    it 'detaches the .dmg file' do
+      p = provider
+      expect(p).to receive(:execute).with('hdiutil detach /Volumes/Steam')
+        .and_yield
+      expect(p).to receive(:only_if).with(
+        "hdiutil info | grep -q 'image-path.*" \
+        "#{Chef::Config[:file_cache_path]}/steam.dmg'"
+      )
+      p.send(:detach_dmg)
+    end
+  end
+
+  describe '#download_path' do
+    it 'returns a path in the Chef cache dir' do
+      expect(provider.send(:download_path)).to eq(
+        "#{Chef::Config[:file_cache_path]}/steam.dmg"
+      )
     end
   end
 end

--- a/spec/libraries/provider_steam_app_spec.rb
+++ b/spec/libraries/provider_steam_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_steam_app'
 
 describe Chef::Provider::SteamApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SteamApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SteamApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do

--- a/spec/libraries/provider_steam_app_windows_spec.rb
+++ b/spec/libraries/provider_steam_app_windows_spec.rb
@@ -76,8 +76,9 @@ describe Chef::Provider::SteamApp::Windows do
 
   describe '#download_path' do
     it 'returns a path under the Chef cache dir' do
-      expected = "#{Chef::Config[:file_cache_path]}/SteamSetup.exe"
-      expect(provider.send(:download_path)).to eq(expected)
+      expect(provider.send(:download_path)).to eq(
+        "#{Chef::Config[:file_cache_path]}/SteamSetup.exe"
+      )
     end
   end
 end

--- a/spec/libraries/provider_steam_app_windows_spec.rb
+++ b/spec/libraries/provider_steam_app_windows_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_steam_app_windows'
 
 describe Chef::Provider::SteamApp::Windows do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SteamApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SteamApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#install!' do
     it 'downloads and installs the package' do

--- a/spec/libraries/resource_steam_app_spec.rb
+++ b/spec/libraries/resource_steam_app_spec.rb
@@ -5,7 +5,8 @@ require_relative '../../libraries/resource_steam_app'
 
 describe Chef::Resource::SteamApp do
   let(:name) { 'default' }
-  let(:resource) { described_class.new(name, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:resource) { described_class.new(name, run_context) }
 
   describe '#initialize' do
     it 'sets the correct resource name' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,11 +25,13 @@ RSpec.configure do |c|
   c.after(:suite) { FileUtils.rm_r(COOKBOOK_PATH) }
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::Console
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    Coveralls::SimpleCov::Formatter,
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ]
+)
 SimpleCov.minimum_coverage(100)
 SimpleCov.start
 


### PR DESCRIPTION
Using the `-quiet` switch when attaching a .dmg results in errors in the most recent versions of mixlib-shellout. The dmg cookbook's behavior can be replicated here until its use of that switch is removed.
